### PR TITLE
Gumgum - ADTS-175 Support multiple GG params

### DIFF
--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -544,6 +544,52 @@ describe('gumgumAdapter', function () {
       const bidRequest = spec.buildRequests(bidRequests)[0];
       expect(!!bidRequest.data.lt).to.be.true;
     });
+
+    it('should handle no gg params', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?param1=foo&param2=bar&param3=baz' } })[0];
+
+      // no params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.false;
+    });
+
+    it('should handle encrypted ad buy id', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?param1=foo&ggad=bar&param3=baz' } })[0];
+
+      // correct params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.true;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.false;
+
+      // params are stripped from pu property
+      expect(bidRequest.data.pu.includes('ggad')).to.be.false;
+    });
+
+    it('should handle unencrypted ad buy id', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?param1=foo&ggad=123&param3=baz' } })[0];
+
+      // correct params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.true;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.false;
+
+      // params are stripped from pu property
+      expect(bidRequest.data.pu.includes('ggad')).to.be.false;
+    });
+
+    it('should handle multiple gg params', function () {
+      const bidRequest = spec.buildRequests(bidRequests, { refererInfo: { referer: 'https://www.prebid.org/?ggdeal=foo&ggad=bar&param3=baz' } })[0];
+
+      // correct params are in object
+      expect(bidRequest.data.hasOwnProperty('eAdBuyId')).to.be.true;
+      expect(bidRequest.data.hasOwnProperty('adBuyId')).to.be.false;
+      expect(bidRequest.data.hasOwnProperty('ggdeal')).to.be.true;
+
+      // params are stripped from pu property
+      expect(bidRequest.data.pu.includes('ggad')).to.be.false;
+      expect(bidRequest.data.pu.includes('ggdeal')).to.be.false;
+    });
   })
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Modified how we detect GG params in the top window's URL in order to allow passing additional params (currently supporting `ggad` and `ggdeal`).

Also, did some structure and syntax cleanup.

@john-ivan 