### PR TITLE
ADSS-1813 fix size in the bid response for multi size slot sizes

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -544,10 +544,10 @@ function interpretResponse(serverResponse, bidRequest) {
     sizes = [`${maxw}x${maxh}`];
   } else if (product === 5 && includes(sizes, '1x1')) {
     sizes = ['1x1'];
-  } else if (product === 2 && includes(sizes, '1x1')) {
+  } else if ((product === 2 && includes(sizes, '1x1')) || product === 3){
     const requestSizesThatMatchResponse = (bidRequest.sizes && bidRequest.sizes.reduce((result, current) => {
       const [ width, height ] = current;
-      if (responseWidth === width || responseHeight === height) result.push(current.join('x'));
+      if (responseWidth === width && responseHeight === height) result.push(current.join('x'));
       return result
     }, [])) || [];
     sizes = requestSizesThatMatchResponse.length ? requestSizesThatMatchResponse : parseSizesInput(bidRequest.sizes)

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -889,7 +889,6 @@ describe('gumgumAdapter', function () {
         body.ad.width = 300;
         body.ad.height = 600;
         result = spec.interpretResponse({ body }, request)[0];
-        console.log(result, 'result==============') // eslint-disable-line
         expect(result.width = expectedSize[1][0]);
         expect(result.height = expectedSize[1][1]);
       })

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -880,6 +880,20 @@ describe('gumgumAdapter', function () {
         expect(result.height = expectedSize[1]);
       })
 
+      it('request size that  matches response size for in-slot', function () {
+        const request = { ...bidRequest };
+        const body = { ...serverResponse };
+        const expectedSize = [[ 320, 50 ], [300, 600], [300, 250]];
+        let result;
+        request.pi = 3;
+        body.ad.width = 300;
+        body.ad.height = 600;
+        result = spec.interpretResponse({ body }, request)[0];
+        console.log(result, 'result==============') // eslint-disable-line
+        expect(result.width = expectedSize[1][0]);
+        expect(result.height = expectedSize[1][1]);
+      })
+
       it('defaults to use bidRequest sizes', function () {
         const { ad, jcsi, pag, thms, meta } = serverResponse
         const noAdSizes = { ...ad }


### PR DESCRIPTION


- [ x] Feature


## Description of change
Fix for multi-size in-slot in our bid response that says that the size of this ad is 300x600 but adapter is interpreting this as a 320x50. 

